### PR TITLE
Fix gametype lingering after plugin unload

### DIFF
--- a/scripting/jumpassist.sp
+++ b/scripting/jumpassist.sp
@@ -25,7 +25,7 @@
 #pragma newdecls required
 #pragma semicolon 1
 
-#define PLUGIN_VERSION "2.4.5"
+#define PLUGIN_VERSION "2.4.6"
 #define PLUGIN_NAME "[TF2] Jump Assist"
 #define PLUGIN_AUTHOR "JoinedSenses (Original author: rush, with previous updates from nolem and happs)"
 #define PLUGIN_DESCRIPTION "Tools to run a jump server with ease."

--- a/scripting/jumpassist.sp
+++ b/scripting/jumpassist.sp
@@ -73,7 +73,8 @@ int
 	g_iIntelCarrier,
 	g_iCPCount,
 	g_iForceTeam = 1,
-	g_iCPsTouched[MAXPLAYERS+1];
+	g_iCPsTouched[MAXPLAYERS+1],
+	g_iInitialGameType;
 float
 	g_fOrigin[MAXPLAYERS+1][3],
 	g_fAngles[MAXPLAYERS+1][3],
@@ -302,6 +303,8 @@ public void OnPluginEnd() {
 		   PrintJAMessage(i, "Plugin reloading: Restoring location");
 		}
 	}
+	
+	GameRules_SetProp("m_nGameType", g_iInitialGameType);
 }
 
 public void OnMapStart() {
@@ -321,6 +324,7 @@ public void OnMapStart() {
 	PrecacheSound("misc/freeze_cam.wav");
 	PrecacheSound("misc/killstreak.wav");
 
+	g_iInitialGameType = GameRules_GetProp("m_nGameType");
 	GameRules_SetProp("m_nGameType", 2);
 
 	HookFuncRegenerate();


### PR DESCRIPTION
The plugin sets `m_nGameType` on load but doesn't reset this prop after being unloaded, causing various gamemodes (such as arena) to break.